### PR TITLE
postcss-nesting 을 추가합니다

### DIFF
--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -7,5 +7,7 @@ module.exports = {
   variants: {
     extend: {},
   },
-  plugins: [],
+  plugins: [
+    require('postcss-nesting')
+  ],
 };


### PR DESCRIPTION
rollup에 의존하지않고 postcss 작업을 tailwindcss 의 postcss 적용 시점에 맡길 수 있습니다

```vue
<style>
button.ui {
  @apply bg-gray-500;

  &.primary {
    @apply bg-blue-500;
  }
}

</style>
```

이렇게 선언 후 빌드 결과물은 다음과 같습니다

```js
var css_248z = "button.ui {\n  --tw-bg-opacity: 1;\n  background-color: rgba(107, 114, 128, var(--tw-bg-opacity))\n}\nbutton.ui.primary {\n    --tw-bg-opacity: 1;\n    background-color: rgba(29, 78, 216, var(--tw-bg-opacity));\n  }\n";
styleInject(css_248z);
```

```css
button.ui {
    --tw-bg-opacity: 1;
    background-color: rgba(107, 114, 128, var(--tw-bg-opacity))
}
button.ui.primary {
      --tw-bg-opacity: 1;
      background-color: rgba(29, 78, 216, var(--tw-bg-opacity));
}
```

원하시는 방법이 맞는지 모르겠네요 `style` 에 lang 등을 쓰시지 않아도 nesting 또는 postcss 관련 라이브러리를 사용하실 수 있을거에요